### PR TITLE
Improvements and added functionality with backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/iktakahiro/slackpy.svg)](https://travis-ci.org/iktakahiro/slackpy)
+
 # slackpy
 
 slackpy is [Slack][] client library for specific logging.
@@ -27,17 +29,22 @@ logging = slackpy.SlackLogger(INCOMING_WEB_HOOK, CHANNEL, USER_NAME)
 ## Minimum Parameter
 ## logging = slackpy.SlackLogger(INCOMING_WEB_HOOK)
 
+LogLevel's only required parameter is "message", all others are optional
+
 # LogLevel: DEBUG
-logging.info(message='INFO Message')
+logging.info(message='INFO Message', title='INFO Title', fallback='', fields='')
 
 # LogLevel: INFO
-logging.info(message='INFO Message')
+logging.info(message='INFO Message', title='INFO Title', fallback='', fields='')
 
 # LogLevel: WARN
-logging.warn(message='WARN Message')
+logging.warn(message='WARN Message', title='INFO Title', fallback='', fields='')
 
 # LogLevel: ERROR
-logging.error(message='ERROR Message')
+logging.error(message='ERROR Message', title='INFO Title', fallback='', fields='')
+
+# LogLevel: CUSTOM
+logging.message(message='CUSTOM Message', title='CUSTOM Title', fallback='CUSTOM Fallback', color='good', fields=[{"title": "CUSTOM", "value": "test", "short": "true"}])
 ```
 
 ### Correspondence table
@@ -70,7 +77,7 @@ slackpy -c '#your_channel' -m 'ERROR Message' -l 40
 slackpy -m 'DEBUG Message' -l 10
 
 # LogLevel: INFO (with Message Title)
-slackpy -c '#your_channel' -t 'Message Title' -m 'INFO Message' -l 20
+slackpy -c '#your_channel' -t 'DEBUG: Message Title' -m 'INFO Message' -l 20
 ```
 
   [Slack]: https://slack.com

--- a/README.txt
+++ b/README.txt
@@ -41,6 +41,9 @@ Sample Code
     # LogLevel: ERROR
     logging.error(message='ERROR Message')
 
+    # LogLevel: CUSTOM
+    logging.message(message='CUSTOM Message', title='CUSTOM Title', fallback='CUSTOM Fallback', color='good', fields=[{"title": "CUSTOM", "value": "test", "short": "true"}])
+
 Correspondence table
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 __author__ = 'Takahiro Ikeuchi'
 
@@ -31,4 +31,3 @@ setup(
         ],
     },
 )
-

--- a/slackpy/slackpy.py
+++ b/slackpy/slackpy.py
@@ -25,18 +25,26 @@ class SlackLogger:
         else:
             raise ValueError('channel must be started with "#" or "@".')
 
-    def __build_payload(self, message, title, color):
+    def __build_payload(self, message, title, color, fallback, fields):
 
-        __fields = {
-            "title": title,
-            "text": message,
-            "color": color,
-            "fallback": title,
-        }
+        if fields is '':
+            __fields = {
+                "title": title,
+                "text": message,
+                "color": color,
+                "fallback": fallback
+            }
 
-        __attachments = {
-            "fields": __fields
-        }
+            __attachments = {
+                "fields": __fields
+            }
+        else:
+            __attachments = [{
+                "fallback": fallback,
+                "color": color,
+                "text": message,
+                "fields": fields
+            }]
 
         payload = {
             "channel": self.channel,
@@ -46,12 +54,15 @@ class SlackLogger:
 
         return payload
 
-    def __send_notification(self, message, title, color='good'):
+    def __send_notification(self, message, title, color='good', fallback='',
+                            fields=''):
         """Send a message to a channel.
         Args:
             title: The message title.
             message: The message body.
-            color: Can either be one of 'good', 'warning', 'danger', or any hex color code
+            color: Can either be one of 'good', 'warning', 'danger',
+                   or any hex color code
+            fallback: What is shown to IRC/fallback clients
 
         Returns:
             api_response:
@@ -59,10 +70,14 @@ class SlackLogger:
         Raises:
             TODO:
         """
-        payload = self.__build_payload(message, title, color)
+        if fallback is '':
+            fallback = title
+
+        payload = self.__build_payload(message, title, color, fallback, fields)
 
         try:
-            response = requests.post(self.web_hook_url, data=json.dumps(payload))
+            response = requests.post(self.web_hook_url,
+                                     data=json.dumps(payload))
 
         except Exception:
             raise Exception(traceback.format_exc())
@@ -74,21 +89,45 @@ class SlackLogger:
             else:
                 raise Exception(response.content.decode())
 
-    def debug(self, message, title='Slack Notification'):
-        title = 'DEBUG : {0}'.format(title)
-        return self.__send_notification(message=message, title=title, color='#03A9F4')
+    def debug(self, message, title='Slack Notification', fallback='',
+              fields=''):
+        return self.__send_notification(message=message,
+                                        title=title,
+                                        color='#03A9F4',
+                                        fallback=fallback,
+                                        fields=fields)
 
-    def info(self, message, title='Slack Notification'):
-        title = 'INFO : {0}'.format(title)
-        return self.__send_notification(message=message, title=title, color='good')
+    def info(self, message, title='Slack Notification', fallback='',
+             fields=''):
+        return self.__send_notification(message=message,
+                                        title=title,
+                                        color='good',
+                                        fallback=fallback,
+                                        fields=fields)
 
-    def warn(self, message, title='Slack Notification'):
-        title = 'WARN : {0}'.format(title)
-        return self.__send_notification(message=message, title=title, color='warning')
+    def warn(self, message, title='Slack Notification', fallback='',
+             fields=''):
+        return self.__send_notification(message=message,
+                                        title=title,
+                                        color='warning',
+                                        fallback=fallback,
+                                        fields=fields)
 
-    def error(self, message, title='Slack Notification'):
-        title = 'ERROR : {0}'.format(title)
-        return self.__send_notification(message=message, title=title, color='danger')
+    def error(self, message, title='Slack Notification', fallback='',
+              fields=''):
+        return self.__send_notification(message=message,
+                                        title=title,
+                                        color='danger',
+                                        fallback=fallback,
+                                        fields=fields)
+
+    def message(self, message, title='Slack Notification', fallback='',
+                color='good', fields=''):
+        return self.__send_notification(message=message,
+                                        title=title,
+                                        color=color,
+                                        fallback=fallback,
+                                        fields=fields)
 
 
 def main():
@@ -96,18 +135,42 @@ def main():
         web_hook_url = os.environ["SLACK_INCOMING_WEB_HOOK"]
 
     except KeyError:
-        print('ERROR: Please set the SLACK_INCOMING_WEB_HOOK variable in your environment.')
+        print('ERROR: Please set the SLACK_INCOMING_WEB_HOOK variable in ' +
+              ' your environment.')
 
     else:
         parser = ArgumentParser(description='slackpy command line tool')
-        parser.add_argument('-m', '--message', type=str, required=True, help='Message')
-        parser.add_argument('-c', '--channel', required=False, help='Channel', default=None)
-        parser.add_argument('-t', '--title', type=str, required=False, help='Title', default='Slack Notification')
-        parser.add_argument('-n', '--name', type=str, required=False, help='Name of Postman', default='Logger')
+        parser.add_argument('-m',
+                            '--message',
+                            type=str,
+                            required=True,
+                            help='Message')
+        parser.add_argument('-c',
+                            '--channel',
+                            required=False,
+                            help='Channel',
+                            default=None)
+        parser.add_argument('-t',
+                            '--title',
+                            type=str,
+                            required=False,
+                            help='Title',
+                            default='Slack Notification')
+        parser.add_argument('-n',
+                            '--name',
+                            type=str,
+                            required=False,
+                            help='Name of Postman',
+                            default='Logger')
 
-        # The purpose of backward compatibility, old args (1, 2, 3) are being retained.
+        # The purpose of backward compatibility, old args (1, 2, 3)
+        # are being retained.
         # DEBUG == 10, INFO == 20, # WARNING == 30, ERROR == 40
-        parser.add_argument('-l', '--level', type=int, default=20, choices=[10, 20, 30, 40, 1, 2, 3])
+        parser.add_argument('-l',
+                            '--level',
+                            type=int,
+                            default=20,
+                            choices=[10, 20, 30, 40, 1, 2, 3])
 
         args = parser.parse_args()
 
@@ -133,4 +196,3 @@ def main():
 
         else:
             print(False)
-

--- a/tests/test_slackpy.py
+++ b/tests/test_slackpy.py
@@ -14,7 +14,11 @@ class TestSlackLogger:
     def test_build_payload_with_all_parameters(self):
 
         logger = SlackLogger('http://dummy_url', '#dummy_channel', 'Test User')
-        actual = logger._SlackLogger__build_payload('Test Message', 'Test Title', 'Color Name')
+        actual = logger._SlackLogger__build_payload('Test Message',
+                                                    'Test Title',
+                                                    'Color Name',
+                                                    'Fallback Text',
+                                                    '')
 
         expected = {
             "channel": "#dummy_channel",
@@ -25,7 +29,7 @@ class TestSlackLogger:
                         "title": "Test Title",
                         "text": "Test Message",
                         "color": "Color Name",
-                        "fallback": "Test Title",
+                        "fallback": "Fallback Text",
                     }
                 }
         }
@@ -35,7 +39,11 @@ class TestSlackLogger:
     def test_build_payload_without_specifying_optional_parameters(self):
 
         logger = SlackLogger('http://dummy_url')
-        actual = logger._SlackLogger__build_payload('Test Message', 'Test Title', 'Color Name')
+        actual = logger._SlackLogger__build_payload('Test Message',
+                                                    'Test Title',
+                                                    'Color Name',
+                                                    'Fallback Text',
+                                                    '')
 
         expected = {
             "channel": None,
@@ -46,9 +54,53 @@ class TestSlackLogger:
                         "title": "Test Title",
                         "text": "Test Message",
                         "color": "Color Name",
-                        "fallback": "Test Title",
+                        "fallback": "Fallback Text",
                     }
                 }
+        }
+
+        assert expected == actual
+
+    def test_build_payload_with_custom_fields(self):
+
+        logger = SlackLogger('http://dummy_url', '#dummy_channel', 'Test User')
+
+        test_fields = []
+        test_fields.append({
+            "title": "Project",
+            "value": "Test Project",
+            "short": "true"
+        })
+        test_fields.append({
+            "title": "Environment",
+            "value": "Test",
+            "short": "true"
+        })
+
+        actual = logger._SlackLogger__build_payload('Test Message',
+                                                    'Test Title',
+                                                    'Color Name',
+                                                    'Fallback Text',
+                                                    test_fields)
+
+        expected = {
+            "channel": "#dummy_channel",
+            "username": "Test User",
+            "attachments":
+                [{
+                    "fallback": "Fallback Text",
+                    "color": "Color Name",
+                    "text": "Test Message",
+                    "fields": [{
+                        "title": "Project",
+                        "value": "Test Project",
+                        "short": "true"
+                    }, {
+                        "title": "Environment",
+                        "value": "Test",
+                        "short": "true"
+                    }]
+                }]
         }
 
         assert expected == actual


### PR DESCRIPTION
Hi!

I was using your library, and was pretty happy with how simple it was, but needed a few more options.

So, here's a list of changes:
- Added the build status of travis
- Extended logging to accept optional "fallback" and "fields" arguments
  - Allowing fallback to be set to something custom helps out our IRC users
  - Allowing custom fields mean we have more power of customizing messages
- Removed prefixes on title's, this allows people to fully customize their own titles (you want to be a helper, not a dictator)
- Added a `message` function, that can be used when you want to log something entirely custom
- Made code compatible with [standard python linters](https://www.python.org/dev/peps/pep-0008/)

When using [custom fields](https://github.com/iktakahiro/slackpy/pull/15/files#diff-066b23e7693983c5d58074e2441538f7R64), you can accomplish the following output:
![screen shot 2015-11-09 at 12 27 15](https://cloud.githubusercontent.com/assets/777823/11032661/896f89a0-86dd-11e5-8f00-70991e350e20.png)

I hope you see this as a valuable addition, if you have any feedback or want more tests, please let me know!

Cheers.
